### PR TITLE
fix UpcomingJournalManager

### DIFF
--- a/erudit/managers/journal.py
+++ b/erudit/managers/journal.py
@@ -50,12 +50,16 @@ class UpcomingJournalManager(MultilingualManager):
     """
 
     def get_queryset(self):
-        is_internal = Q(redirect_to_external_url=False)
-        no_published_issues = Q(issues=None) | ~Q(issues__is_published=True)
+        is_external = Q(redirect_to_external_url=True)
+        no_issues = Q(issues=None)
+        has_unpublished_issues = Q(issues__is_published=False)
+        has_published_issues = Q(issues__is_published=True)
 
         return super().get_queryset().filter(
-            is_internal & no_published_issues
-        )
+            no_issues | has_unpublished_issues
+        ).exclude(
+            has_published_issues | is_external
+        ).distinct()
 
 
 class InternalIssueManager(models.Manager):

--- a/tests/unit/test_managers.py
+++ b/tests/unit/test_managers.py
@@ -28,12 +28,28 @@ class TestJournalUpcomingManager(object):
         # Check
         assert list(journals) == []
 
-    def test_journals_with_unpublished_issues_are_upcoming(self):
+    def test_external_journals_with_unpublished_issues_are_not_upcoming(self):
+        # Setup
+        JournalFactory(redirect_to_external_url=True)
+        journal_1 = JournalFactory(redirect_to_external_url=True)
+        IssueFactory(journal=journal_1, is_published=False)
+        # Test
+        assert list(Journal.upcoming_objects.all()) == []
+
+    def test_journals_with_published_and_unpublished_issues_are_not_upcoming(self):
         # Setup
         journal_1 = JournalFactory.create_with_issue()
         IssueFactory(journal=journal_1, is_published=False)
         # Test
-        assert list(Journal.upcoming_objects.all()) == [journal_1]
+        assert list(Journal.upcoming_objects.all()) == []
+
+    def test_journals_with_unpublished_issues_are_upcoming(self):
+        # Setup
+        journal_1 = JournalFactory()
+        IssueFactory(journal=journal_1, is_published=False)
+        # Test
+        journals = Journal.upcoming_objects.all()
+        assert list(journals) == [journal_1]
 
 
 class TestInternalJournalManager(BaseEruditTestCase):


### PR DESCRIPTION
Filter external journals. Journals with an unpublished and a published
issue are not upcoming.

ref #3070