### PR TITLE
Do not return thumbnail image info

### DIFF
--- a/erudit/fedora/objects.py
+++ b/erudit/fedora/objects.py
@@ -98,13 +98,11 @@ class ArticleDigitalObject(models.DigitalObject):
         infoimg_tree = et.fromstring(self.infoimg.content.serialize())
         infoimg_dict = OrderedDict()
         for im_tree in infoimg_tree.findall('im'):
-            src_node = im_tree.find('src//nomImg')
             plgr_node = im_tree.find('imPlGr//nomImg')
-            if src_node is None or plgr_node is None:
+            if plgr_node is None:
                 continue
             infoimg_dict.update({
                 im_tree.get('id'): {
-                    'src': src_node.text,
                     'plgr': plgr_node.text,
                 },
             })

--- a/tests/unit/fedora/test_objects.py
+++ b/tests/unit/fedora/test_objects.py
@@ -105,4 +105,4 @@ class TestArticleDigitalObject(TestCase):
         )
         article = ArticleDigitalObject(api, 'test')
         # Run & check
-        self.assertEqual(article.infoimg_dict, {'im1': {'src': 'foo.jpg', 'plgr': 'bar.jpg'}})
+        self.assertEqual(article.infoimg_dict, {'im1': {'plgr': 'bar.jpg'}})


### PR DESCRIPTION
They are no longer used, and TEI-produced articles don't have this in `infoimg.xml`